### PR TITLE
Fix compile errors with Blinky

### DIFF
--- a/Blinky/Blinky.bgs
+++ b/Blinky/Blinky.bgs
@@ -3,6 +3,10 @@ dim port
 dim led_value
 dim read_result
 dim connected 
+dim mac_addr(6)
+dim tmp(20)
+dim command
+dim dfu_pointer
 
 # Constants
 const TIMER_SECONDS = 1


### PR DESCRIPTION
A couple of variables were not defined, so I defined them so now it will
compile
